### PR TITLE
Add `no_std` including example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
 - |
   travis-cargo build &&
   travis-cargo test &&
+  travis-cargo test -- --no-default-features --features libm &&
   travis-cargo bench &&
   travis-cargo --only stable doc
 after_success:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude=[".travis.yml"]
 [features]
 default = ["std"]
 std = ["num-traits/std"]
+libm = ["num-traits/libm"]
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,12 @@ keywords=["easing","animation","tween"]
 license="MIT"
 exclude=[".travis.yml"]
 
+[features]
+default = ["std"]
+std = ["num-traits/std"]
+
 [dependencies]
-num-traits="0.2"
+num-traits = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 approx="0.2"

--- a/examples/embedded/.cargo/config
+++ b/examples/embedded/.cargo/config
@@ -1,0 +1,8 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "nrfdfu"
+rustflags = [
+    "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "thumbv7em-none-eabihf"

--- a/examples/embedded/Cargo.toml
+++ b/examples/embedded/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "easer-embedded-demo"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.7.3"
+cortex-m-rt = "0.7.0"
+nb = "1.0.0"
+nrf52840-hal = "0.15.1"
+easer = { version = "0.2.1", default-features = false, features = ["libm"] }
+panic-reset = "0.1.1"
+num-traits = { version = "0.2.15", default-features = false, features = ["libm"] }
+
+[patch.crates-io]
+easer = { path = "../../" }

--- a/examples/embedded/README.md
+++ b/examples/embedded/README.md
@@ -1,0 +1,24 @@
+Simple example showing how `easer` can be used in embedded `no_std` contexts.
+
+This example is designed to be run on the [MDBT50Q-RX
+dongle](https://www.adafruit.com/product/5199), but should be easily adapted to
+other nrf52840-based boards by changing the LED pin number.
+
+# Flashing/running
+
+If your board has an `nrfdfu`-compatible bootloader installed,
+
+```shell
+cargo install nrfdfu
+cargo run --release
+```
+
+If your board has a UF2-compatible bootloader installed (such as the stock
+Adafruit bootloader),
+
+```shell
+cargo install cargo-binutils uf2conv
+cargo objcopy --release -- -O binary flash.bin
+uf2conv flash.bin --base 0x26000 --family 0xADA52840
+cp flash.bin /Volumes/MDBT50QBOOT/
+```

--- a/examples/embedded/memory.x
+++ b/examples/embedded/memory.x
@@ -1,0 +1,7 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  /* These values correspond to the NRF52840 with Softdevices S140 6.1.1 */
+  FLASH : ORIGIN = 0x00026000, LENGTH = 868K
+  RAM : ORIGIN = 0x20020000, LENGTH = 128K
+}

--- a/examples/embedded/src/main.rs
+++ b/examples/embedded/src/main.rs
@@ -1,0 +1,46 @@
+#![no_main]
+#![no_std]
+
+use easer::functions::*;
+use hal::{prelude::*, pwm, pwm::Pwm, Rtc};
+use nrf52840_hal as hal;
+use nrf52840_hal::gpio::Level;
+use num_traits::Float;
+use panic_reset as _;
+
+// RTC will count at ~100 Hz
+const RTC_PRESCALER: u32 = 327;
+// Tick is ~10 ms
+const TICK: f32 = (RTC_PRESCALER as f32 + 1.0) / 32768.0;
+// Run animation for 5 seconds
+const DURATION: f32 = 5.0;
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    let p = hal::pac::Peripherals::take().unwrap();
+    let port1 = hal::gpio::p1::Parts::new(p.P1);
+    let led = port1.p1_13.into_push_pull_output(Level::Low);
+
+    // Enable the low-power/low-frequency clock which is required by the RTC.
+    let clocks = hal::clocks::Clocks::new(p.CLOCK);
+    let _clocks = clocks.start_lfclk();
+
+    let rtc = Rtc::new(p.RTC0, RTC_PRESCALER).unwrap();
+    rtc.enable_counter();
+
+    let pwm = Pwm::new(p.PWM0);
+    pwm.set_period(1000u32.hz());
+    pwm.set_max_duty(32767);
+    pwm.set_output_pin(pwm::Channel::C0, led.degrade());
+    pwm.enable();
+
+    loop {
+        let time = rtc.get_counter();
+        let time_s = (time as f32) * TICK;
+
+        let brightness = Bounce::ease_in_out(time_s % DURATION, 0.0, 1.0, DURATION);
+
+        // Apply a gamma of 3.0 so that the brightness change is perceptable.
+        pwm.set_duty_on_common((brightness.powi(3) * (pwm.get_max_duty() as f32)) as u16);
+    }
+}

--- a/src/functions/elastic.rs
+++ b/src/functions/elastic.rs
@@ -2,7 +2,7 @@ use super::ease::Easing;
 use functions::util::*;
 use num_traits::float::FloatConst;
 
-/// This) struct captures Elastic easing functions
+/// This struct captures Elastic easing functions
 #[derive(Debug)]
 pub struct Elastic;
 

--- a/src/functions/util.rs
+++ b/src/functions/util.rs
@@ -11,7 +11,7 @@ pub fn f<F: Float>(x: f64) -> F {
 /// equation readability by using constants like `_1_23`
 ///
 /// `cast_constants!(F; _1_23=1.23, _10=10);` is equivalent to
-/// ```
+/// ```no_run,ignore
 /// let _1_23: F = f(1.23);
 /// let _10: F = f(10 as f64);
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! println!("After {:?}", &y[..]);
 //!
 //! ```
+#![no_std]
 extern crate num_traits;
 
 pub mod functions;


### PR DESCRIPTION
It looks like you might've done a force push that removed commit fc43a525125c42d6d96cfda15a7694689067674f. The commit looks good so I've kept it in my branch.

Other than that, the vast majority of this PR is adding an example as requested. IMO it's not worth the baggage to see exactly the same code usage, but *shrug*.